### PR TITLE
Ruby 2.4 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 
 rvm:
+  - "2.7"
   - "2.6"
+  - "2.5"
+  - "2.4"
 
 gemfile:
   - Gemfile


### PR DESCRIPTION
I know Ruby 2.4 is no longer supported (as of 2020-04-05), so you may not be interested in these changes. But after stumbling into this library, it closely matches what I had been looking for, but I still have a couple legacy use-cases that are on Ruby 2.4. I found that the changes necessary to support Ruby 2.4 weren't huge (different namespace for `pbkdf2_hmac` and no support for `delete_prefix`), so if you're interested in these changes, I thought I'd open up a pull request. But in any case, thanks for this library!