### PR TITLE
Fix "instance variable not initialized" warnings

### DIFF
--- a/lib/secret_keys.rb
+++ b/lib/secret_keys.rb
@@ -112,6 +112,9 @@ class SecretKeys < DelegateClass(Hash)
   # @note If no encryption key is passed, this will defautl to env var SECRET_KEYS_ENCRYPTION_KEY
   # or (if that is empty) the value read from the file path in SECRET_KEYS_ENCRYPTION_KEY_FILE.
   def initialize(path_or_stream, encryption_key = nil)
+    @encryption_key = nil
+    @salt = nil
+
     encryption_key = read_encryption_key(encryption_key)
     update_secret(key: encryption_key)
     path_or_stream = Pathname.new(path_or_stream) if path_or_stream.is_a?(String)
@@ -407,7 +410,7 @@ class SecretKeys < DelegateClass(Hash)
     # Don't accidentally return the secret, dammit
     nil
   end
-  
+
   # Logic to read an encryption key from environment variables if it is not explicitly supplied.
   # If it isn't specified, the value will be read from the SECRET_KEYS_ENCRYPTION_KEY environment
   # variable. Otherwise, it will be tried to read from the file specified by the

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,7 @@ require_relative "../lib/secret_keys.rb"
 
 require "tempfile"
 require "climate_control"
+
+RSpec.configure do |config|
+  config.warnings = true
+end


### PR DESCRIPTION
When run with Ruby warnings enabled, there could be some small warnings about instance variables being undefined:

```
lib/secret_keys.rb:402: warning: instance variable @salt not initialized
lib/secret_keys.rb:120: warning: instance variable @salt not initialized
lib/secret_keys.rb:402: warning: instance variable @encryption_key not initialized
```

This fixes the warnings and enables warnings in the rspec test suite by default, so Ruby warnings are surfaced more obviously.

This is admittedly a small thing that's not really causing any issues. I just happened to notice it when running a test suite that uses secret_keys that had warnings enabled by default, and thought it might be nice to address. Thanks!