### PR TITLE
Remove base64 dependency and exclude newlines

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Follow [RFC 4648](https://www.ietf.org/rfc/rfc4648.txt) base 64 encoding, removing line-feeds from the encoded data.
+
 ## v1.0.1 (June 01, 2020)
 
 - Fix missing documentation links

--- a/lib/secret_keys/encryptor.rb
+++ b/lib/secret_keys/encryptor.rb
@@ -2,7 +2,6 @@
 
 require "securerandom"
 require "openssl"
-require "base64"
 
 # Encyption helper for encrypting and decrypting values using AES-256-GCM and returning
 # as Base64 encoded strings. The encrypted values also include a prefix that can be used
@@ -138,13 +137,13 @@ class SecretKeys::Encryptor
   # Receive a cipher object (initialized with key) and data
   def encode_aes(params)
     encoded = params.values.pack(ENCODING_FORMAT)
-    # encode base64 and get rid of trailing newline and unnecessary =
-    Base64.encode64(encoded).chomp.tr("=", "")
+    # encode base64 and get rid of unnecessary '=' padding
+    [encoded].pack("m0").tr("=", "")
   end
 
   # Passed in an aes encoded string and returns a cipher object
   def decode_aes(str)
-    unpacked_data = Base64.decode64(str).unpack(ENCODING_FORMAT)
+    unpacked_data = str.unpack1("m").unpack(ENCODING_FORMAT)
     # Splat the data array apart
     # nonce, auth_tag, encrypted_data = unpacked_data
     CipherParams.new(*unpacked_data)

--- a/spec/secret_keys/encryptor_spec.rb
+++ b/spec/secret_keys/encryptor_spec.rb
@@ -13,6 +13,14 @@ describe SecretKeys::Encryptor do
       expect(encryptor.decrypt(encrypted)).to eq "stuff"
     end
 
+    it "should encode data without linefeeds or padding" do
+      long_line = "Hello, world!" * 100
+      encrypted = encryptor.encrypt(long_line)
+      expect(encrypted).to_not include "="
+      expect(encrypted).to_not include "\n"
+      expect(encryptor.decrypt(encrypted)).to eq long_line
+    end
+
     it "should never encrypt a value the same way twice" do
       encrypted_1 = encryptor.encrypt("stuff")
       encrypted_2 = encryptor.encrypt("stuff")


### PR DESCRIPTION
By default, Ruby's `Base64.encode64` function is implemented following RFC 2045 which adds newlines every 60 characters. This is kinda silly and was superseded in RFC 4648 which instead recommends only adding newlines if the underlying storage (e.g. MIME headers) strictly requires it.

Because the `encode64` and `decode64` functions are just super lightweight wrappers around the underlying string packing calls, pack the data directly and specify `"m0"` for encoding which tells the packing to never add newlines.

All of the data is used entirely internally, so this should be safe to bump as a patch version.